### PR TITLE
[BUGFIX] Buffer goes out of scope before unit test can check it

### DIFF
--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -23,19 +23,36 @@ void resetFakes(void) {
   FFF_RESET_HISTORY();
 }
 
+uint8_t customFakeTxBuff[2] = {0};
+
+// This function is needed because the buff passed into i2cSendTo goes out of scope
+// before the test can check it
+error_code_t i2cSendTo_custom_fake(uint8_t addr, uint8_t *buff, uint16_t numBytes) {
+  if (addr != 0x4FU) {
+    return ERR_CODE_I2C_TRANSFER_TIMEOUT;
+  }
+
+  uint8_t numToCopy = numBytes < 2 ? numBytes : 2;
+  memcpy(customFakeTxBuff, buff, numToCopy);
+
+  return ERR_CODE_SUCCESS;
+}
+
 TEST(TestLm75bdDriver, TestWriteConfigLm75bdSuccess) {
   resetFakes();
 
   uint8_t addr = 0x4FU;
 
+  i2cSendTo_fake.custom_fake = i2cSendTo_custom_fake;
   i2cSendTo_fake.return_val = ERR_CODE_SUCCESS;
+
   ASSERT_EQ(writeConfigLM75BD(0x4FU, 1, 0, 1, 0), ERR_CODE_SUCCESS);
 
   const uint8_t expectedBuff[2] = {0x1U, 0b00000010U};
 
   EXPECT_EQ(i2cSendTo_fake.call_count, 1);
   EXPECT_EQ(i2cSendTo_fake.arg0_val, addr); // Check device address
-  EXPECT_EQ(memcmp(i2cSendTo_fake.arg1_val, expectedBuff, 2), 0); // Check buffer (reg addr + config byte)
+  EXPECT_EQ(memcmp(customFakeTxBuff, expectedBuff, 2), 0); // Check buffer (reg addr + config byte)  
   EXPECT_EQ(i2cSendTo_fake.arg2_val, 2U); // Check numBytes
 }
 
@@ -90,7 +107,9 @@ TEST(TestLm75bdDriver, TestReadTempLm75bdCallSequence) {
   uint8_t addr = 0x4FU;
   float temp;
 
+  i2cSendTo_fake.custom_fake = i2cSendTo_custom_fake;
   i2cReceiveFrom_fake.return_val = ERR_CODE_SUCCESS;
+
   ASSERT_EQ(readTempLM75BD(addr, &temp), ERR_CODE_SUCCESS);
 
   EXPECT_EQ(i2cReceiveFrom_fake.call_count, 1);
@@ -102,7 +121,7 @@ TEST(TestLm75bdDriver, TestReadTempLm75bdCallSequence) {
 
   // Check call arguments
   EXPECT_EQ(i2cSendTo_fake.arg0_val, addr); // Check device address
-  EXPECT_EQ(i2cSendTo_fake.arg1_val[0], 0x0U); // Check buffer (reg addr)
+  EXPECT_EQ(customFakeTxBuff[0], 0x0U); // Check buffer (reg addr)
   EXPECT_EQ(i2cSendTo_fake.arg2_val, 1U); // Check numBytes
 
   EXPECT_EQ(i2cReceiveFrom_fake.arg0_val, addr); // Check device address


### PR DESCRIPTION
# Purpose
Fixed bug where the buffer passed into `i2cSendTo` goes out of scope before we can check it in the unit test. This resulted in tests being inconsistent.

# New Changes
- Created a custom mock to copy the buffer contents to a `static` buffer.

# Testing
- Tested against my own solution to the onboarding.

# Outstanding Changes
N/A