### PR TITLE
[BUGFIX] Fixed failing CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
 
     - name: Setup
       run: |
+        sudo apt-get update
         sudo apt-get -y install build-essential cmake
 
     - name: Create binary directory

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -9,6 +9,7 @@ jobs:
 
     - name: Setup
       run: |
+        sudo apt-get update
         sudo apt-get -y install build-essential cmake expect
 
     - name: Create binary directory


### PR DESCRIPTION
# Purpose
Modified workflows to run `apt-get update`

Builds fail due to an incomplete challenge solution, but it completes the package installation step so the change works as intended.