### PR TITLE
Make OBC unit tests 32 bit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install GNU cross compilation
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib g++-multilib
     - name: Configure CMake
       run: |
         mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.15)
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchain_gcc.cmake)
 
 if (CMAKE_BUILD_TYPE MATCHES Test)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
     include(cmake/fetch_googletest.cmake)
     enable_testing()
 endif()

--- a/cmake/fetch_googletest.cmake
+++ b/cmake/fetch_googletest.cmake
@@ -12,6 +12,8 @@ FetchContent_Declare(
     GIT_PROGRESS    TRUE
     USES_TERMINAL_DOWNLOAD TRUE
 )
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 add_library(GTest::GTest INTERFACE IMPORTED)
 target_link_libraries(GTest::GTest INTERFACE gtest_main)


### PR DESCRIPTION
# New Changes
- Add `-m32` compiler arg when building tests
- Add step in Tests github action to download gcc-multilib and g++-multilib (to compile the tests with `-m32`)

# Testing
- Pulled this branch into a verified onboarding solution to validate that it still passes tests